### PR TITLE
build: 更新spring-boot-starter-parent到3.0.0-M4

### DIFF
--- a/app1/binarytea/pom.xml
+++ b/app1/binarytea/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M2</version>
+		<version>3.0.0-M4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>learning.spring</groupId>

--- a/app1/customer/pom.xml
+++ b/app1/customer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M2</version>
+		<version>3.0.0-M4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>learning.spring</groupId>


### PR DESCRIPTION
将springboot启动父POM依赖从3.0.0-M2更新到3.0.0-M4，以利用最新版本改进的功能和修复。 更改适用于app1/binarytea和app1/customer模块。
参考 :https://stackoverflow.com/questions/73619993/spring-project-non-resolvable-import-pom-failure-to-find-io-micrometermicrom


>  Since Spring Boot 3.0.0-M2 was released, the Micrometer 2.0 release upon which it depends was abandoned and replaced with a backwards-compatible 1.10 release instead. As part of this, to avoid confusion about the latest version, the Micrometer team took the decision to delete the 2.0 artifacts from https://repo.spring.io/. An unfortunate consequence of this is that Spring Boot 3.0.0-M2 is no longer usable. At the time of writing, the latest milestone of Spring Boot 3.0 is 3.0.0-M4. Upgrading to it will resolve your problem. It depends on a Micrometer 1.10 milestone.

